### PR TITLE
Enable the adb over vsock support.

### DIFF
--- a/host/src/pack/dpkg/opt/cfc/mwc/bin/killapp.sh
+++ b/host/src/pack/dpkg/opt/cfc/mwc/bin/killapp.sh
@@ -8,7 +8,7 @@ then
     exit 1
 fi
 
-adb shell am force-stop $1
+adb -s vsock:3:5555 shell am force-stop $1
 
 exit 0
 

--- a/host/src/pack/dpkg/opt/cfc/mwc/bin/loadapp.sh
+++ b/host/src/pack/dpkg/opt/cfc/mwc/bin/loadapp.sh
@@ -8,7 +8,7 @@ then
     exit 1
 fi
 
-adb shell am start -n $2 --display $3
+adb -s vsock:3:5555 shell am start -n $2 --display $3
 /opt/lg/bin/LG_B1_Client -M yes -R 16666 -f /dev/shm/looking-glass$3 -a true -t $1
 
 

--- a/host/src/pack/dpkg/opt/cfc/mwc/bin/loadapp_single_lg.sh
+++ b/host/src/pack/dpkg/opt/cfc/mwc/bin/loadapp_single_lg.sh
@@ -8,7 +8,7 @@ then
     exit 1
 fi
 
-adb shell am start -n $2 --display 0
+adb -s vsock:3:5555 shell am start -n $2 --display 0
 
 num_lg_insts=`ps aux | grep LG_B1_Client | grep -v guestClipboard.*enable.*true | grep -v grep | wc -l`
 

--- a/host/src/pghost/AdbProxy.cpp
+++ b/host/src/pghost/AdbProxy.cpp
@@ -172,7 +172,11 @@ bool AdbProxy::getDeviceName() {
     }
     // find a online device
     while (!feof(pf) && fgets(mMsgBuf, kMsgBufSize, pf)) {
+#ifdef VSOCK_ADB
+      if (strstr(mMsgBuf, "vsock") && strstr(mMsgBuf, "\tdevice")) {
+#else
       if (strstr(mMsgBuf, "\tdevice")) {
+#endif
         char name[32];
         sscanf(mMsgBuf, "%32s", name);
         mDeviceName = name;

--- a/host/src/pghost/AdbProxy.h
+++ b/host/src/pghost/AdbProxy.h
@@ -109,11 +109,20 @@ class AdbProxy : public AmInterface {
   static const int kMsgBufSize = 1024;
   const char* msgDeviceList = "adb devices";
   const char* msgDeviceListHead = "List of devices attached";
+#ifdef VSOCK_ADB
+  const char* msgConnect = "adb connect vsock:3:5555";
+  const char* msgConnectOk = "connected to vsock:3:5555";
+#else
   const char* msgConnect = "adb connect localhost";
   const char* msgConnectOk = "connected to localhost:5555";
+#endif
   const char* msgErrorBroken = "error: device not found";
   const char* msgErrorOffline = "error: device offline";
+#ifdef VSOCK_ADB
+  const char* msgAndroidVerison = "adb -s vsock:3:5555 shell getprop | grep -i ro.system.build.version.release";
+#else
   const char* msgAndroidVerison = "adb shell getprop | grep -i ro.system.build.version.release";
+#endif
   const int KEYCODE_HOME = 3;
   const int KEYCODE_BACK = 4;
   const int KEYCODE_MENU = 82;

--- a/host/src/pghost/Makefile
+++ b/host/src/pghost/Makefile
@@ -1,4 +1,4 @@
-CC = g++ -fpermissive -I/usr/include/jsoncpp -DLG_SINGLE_MODE
+CC = g++ -fpermissive -I/usr/include/jsoncpp -DLG_SINGLE_MODE -DVSOCK_ADB
 #CC_FLAGS = -g -Wall -lpthread -lsqlite3
 CC_FLAGS = -g -Wall -lpthread -fPIC  -ljsoncpp -I/usr/include/jsoncpp
 #CC_FLAGS_CD = -g -Wall -lpthread -lX11 -ljpeg -I. -I/usr/include/libpng12 -ljpeg -lpng12

--- a/host/src/pghost/ShortcutMgrLg.cpp
+++ b/host/src/pghost/ShortcutMgrLg.cpp
@@ -226,8 +226,8 @@ int ShortcutMgrLg::updateInstalledApps()
     if (home) {
 	snprintf(filepath, sizeof(filepath), "%s/.installed_apps.json", home);
 	char cmdbuf[512];
-	snprintf(cmdbuf, sizeof(cmdbuf), "adb pull /sdcard/installed_apps.json %s", filepath);
-	system(cmdbuf);
+	snprintf(cmdbuf, sizeof(cmdbuf), "pull /sdcard/installed_apps.json %s", filepath);
+        m_adbproxy_->runCmd(cmdbuf);
 	Json::Value root;
 	std::ifstream ifs;
 	ifs.open(filepath);
@@ -287,8 +287,8 @@ const char* ShortcutMgrLg::getInstalledAppsV1()
     if (home) {
 	snprintf(filepath, sizeof(filepath), "%s/.installed_apps_v1.json", home);
 	char cmdbuf[512];
-	snprintf(cmdbuf, sizeof(cmdbuf), "adb pull /sdcard/installed_apps_v1.json %s", filepath);
-	system(cmdbuf);
+        snprintf(cmdbuf, sizeof(cmdbuf), "pull /sdcard/installed_apps_v1.json %s", filepath);
+        m_adbproxy_->runCmd(cmdbuf);
 	Json::Value root;
 	std::ifstream ifs;
 	ifs.open(filepath);

--- a/host/src/pghost/killapp.sh
+++ b/host/src/pghost/killapp.sh
@@ -8,7 +8,7 @@ then
     exit 1
 fi
 
-adb shell am force-stop $1
+adb -s vsock:3:5555 shell am force-stop $1
 
 exit 0
 

--- a/host/src/pghost/loadapp.sh
+++ b/host/src/pghost/loadapp.sh
@@ -8,7 +8,7 @@ then
     exit 1
 fi
 
-adb shell am start -n $2 --display $3
+adb -s vsock:3:5555 shell am start -n $2 --display $3
 /opt/lg/bin/LG_B1_Client -M yes -R 16666 -f /dev/shm/looking-glass$3 -a true -t $1
 
 

--- a/host/src/pghost/loadapp_single_lg.sh
+++ b/host/src/pghost/loadapp_single_lg.sh
@@ -8,7 +8,7 @@ then
     exit 1
 fi
 
-adb shell am start -n $2 --display 0
+adb -s vsock:3:5555 shell am start -n $2 --display 0
 
 num_lg_insts=`ps aux | grep LG_B1_Client | grep -v guestClipboard.*enable.*true | grep -v grep | wc -l`
 


### PR DESCRIPTION
For security reason, adb over socket will be disabled and adb over
vsock will be used. To adapt this change, app icon manager needs
to use vsock adb instead of existing socket forwarding approach.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>
Tracked-On: OAM-99827