### PR TITLE
Minor fixes for PGP

### DIFF
--- a/host/src/pack/dpkg/etc/rc.civ
+++ b/host/src/pack/dpkg/etc/rc.civ
@@ -44,13 +44,13 @@ then
        mkdir -p $HOME/Android/Download -m 0777
    fi
 
-   if [ ! -d $HOME/桌面/拓展应用文件夹/微信图片 ]
+   if [ ! -L $HOME/桌面/拓展应用文件夹/微信图片 ]
    then
       mkdir -p $HOME/桌面/拓展应用文件夹
       ln -s $HOME/Android/Pictures/WeiXin/ $HOME/桌面/拓展应用文件夹/微信图片
    fi
 
-   if [ ! -d $HOME/桌面/拓展应用文件夹/微信下载 ]
+   if [ ! -L $HOME/桌面/拓展应用文件夹/微信下载 ]
    then
       mkdir -p $HOME/桌面/拓展应用文件夹
       ln -s $HOME/Android/Download/WeiXin/ $HOME/桌面/拓展应用文件夹/微信下载

--- a/host/src/pack/dpkg/etc/rc.civ.post
+++ b/host/src/pack/dpkg/etc/rc.civ.post
@@ -7,7 +7,7 @@ function is_civ_ready() {
         timeout 1 adb connect vsock:3:5555 && break
     done
 
-    for i in {0..9}; do
+    for i in {0..19}; do
         if [ "$(adb -s vsock:3:5555 shell getprop sys.boot_completed)" == "1" ] ; then
             return 0
             break

--- a/host/src/pack/dpkg/opt/cfc/mwc/bin/resume_civ.sh
+++ b/host/src/pack/dpkg/opt/cfc/mwc/bin/resume_civ.sh
@@ -67,5 +67,14 @@ function resume_civ()
     return -1
 }
 
+function toggle_status()
+{
+    echo "Send QMP: toggle_instance_status, value=1"
+    local out
+    echo "{ \"execute\": \"toggle_instance_status\", \"arguments\": { \"value\": 1 } }" >&4
+    read -u 5 -t 1 -r out && echo "OUTPUT: $out"
+}
+
 connect_qmp || exit -1
 resume_civ || exit -1
+toggle_status


### PR DESCRIPTION
1. toggle instance status to 1 when resume civ
2. iterate more times for waiting android boot_completed
3. check symbolic(-L) for wexin pictures/downloads

Signed-off-by: Yadong Qi <yadong.qi@intel.com>