### PR TITLE
Kill xueersi exception process

### DIFF
--- a/host/src/pack/dpkg/opt/cfc/mwc/bin/lg_launcher.sh
+++ b/host/src/pack/dpkg/opt/cfc/mwc/bin/lg_launcher.sh
@@ -52,9 +52,23 @@ then
         echo "Close previous opened app: $previous_app"
         /opt/cfc/mwc/bin/resume_civ.sh
         adb -s vsock:3:5555 shell am force-stop $previous_app
+        adb -s vsock:3:5555 shell am kill $previous_app
     else
         echo "Open same app, do nothing."
     fi
+fi
+
+if [ "$1" =  "com.xes.jazhanghui.activity" ];
+then
+    xersi_proc_num=`adb -s vsock:3:5555 shell ps -A | grep "com.xes.jazhanghui.activity" | awk -F ' ' {'print $2'} | wc -l`
+    if [ $xersi_proc_num -eq  1 ];
+    then
+       xersicore_pid=`adb -s vsock:3:5555 shell ps -A | grep "com.xes.jazhanghui.activity:core" | awk -F ' ' {'print $2'} `
+       if [ $xersicore_pid -ge 0 ];
+       then
+           adb -s vsock:3:5555 shell kill -9 $xersicore_pid
+       fi
+   fi
 fi
 
 # Balloon Guest memory to 2048MB if no mwc_launcher live


### PR DESCRIPTION
Xueersi has 2 process com.xes.jazhanghui.activity and
com.xes.jazhanghui.activity:core, but for some unknown reason
the com.xes.jazhanghui.activity:core didn't exit properly after
com.xes.jazhanghui.activity exit, and result in Xueersi APP crash
during next time executed.

TO fix this issue, during Xueersi launch time check whether
there is a single com.xes.jazhanghui.activity:core process in system
and kill it if yes.

Tracked-On: OAM-100046
Signed-off-by: Yang, Dong <dong.yang@intel.com>