### PR TITLE
Added the feature to generate radious corner icon.

### DIFF
--- a/guest/agent-client/pm-agent-client.cpp
+++ b/guest/agent-client/pm-agent-client.cpp
@@ -151,30 +151,25 @@ static int dump_app_desktop_files ()
 		return -1;
 	    }
 
-	    if (access(fapp_desktop_launcher.c_str(), F_OK) != 0) {
+            FILE* fp = fopen(fapp_desktop_launcher .c_str(), "wb");
+            if (fp == 0) {
+		fprintf(stderr, "Failed to create desktop file %s:%s", fapp_desktop_launcher.c_str(),
+                                 strerror(errno));
+                return -1;
+            }
 
-		FILE* fp = fopen(fapp_desktop_launcher .c_str(), "wb");
-		if (fp == 0) {
-		    fprintf(stderr, "Failed to create desktop file %s:%s", fapp_desktop_launcher.c_str(),
-			    strerror(errno));
-		    return -1;
-		}
-
-		fprintf(fp, "[Desktop Entry]\n");
-                fprintf(fp, "Name=%s\n", String8(appname).string());
-		fprintf(fp, "Name[zh_CN]=%s\n", String8(appname).string());
-		fprintf(fp, "Comment=Android App %s\n", String8(pkg).string());
-		fprintf(fp, "Exec=/opt/cfc/mwc/bin/lg_launcher.sh %s %s %s\n",String8(pkg).string(), String8(intent).string(), String8(appname).string());
-		fprintf(fp, "Icon=~/.local/share/applications/icon/%s.png\n",  String8(pkg).string());
-		fprintf(fp, "Type=Application\n");
-		fprintf(fp, "Terminal=false\n");
-		fprintf(fp, "Categories=Application\n");
-		fprintf(fp, "X-Desktop-File-Install-Version=0.24\n");
-                fprintf(fp, "APKVersion=%s\n", String8(appversion).string());
-		fclose(fp);
-
-	    }
-
+            fprintf(fp, "[Desktop Entry]\n");
+            fprintf(fp, "Name=%s\n", String8(appname).string());
+            fprintf(fp, "Name[zh_CN]=%s\n", String8(appname).string());
+            fprintf(fp, "Comment=Android App %s\n", String8(pkg).string());
+            fprintf(fp, "Exec=/opt/cfc/mwc/bin/lg_launcher.sh %s %s %s\n",String8(pkg).string(), String8(intent).string(), String8(appname).string());
+            fprintf(fp, "Icon=~/.local/share/applications/icon/%s.png\n",  String8(pkg).string());
+            fprintf(fp, "Type=Application\n");
+            fprintf(fp, "Terminal=false\n");
+            fprintf(fp, "Categories=Application\n");
+            fprintf(fp, "X-Desktop-File-Install-Version=0.24\n");
+            fprintf(fp, "APKVersion=%s\n", String8(appversion).string());
+            fclose(fp);
 
 	    std::vector<uint8_t> icon;
 	    status = pma->getIcon(pkg, &icon);


### PR DESCRIPTION
For non-adaptive icon, Android SDK api may returns the square
corner icon and this makes the icons user experience is not
consistent. Added the feature to generate radious corner icon for
non-adaptive icon returned.

Fixed the cached .desktop file doesn't update issue.

Signed-off-by: Wan Shuang <shuang.wan@intel.com>
Tracked-On: OAM-100461