### PR TITLE
correct the flock usage

### DIFF
--- a/host/src/pack/dpkg/etc/rc.civ.post
+++ b/host/src/pack/dpkg/etc/rc.civ.post
@@ -65,6 +65,10 @@ balloon_civ
 
 /opt/lg/bin/LG_B1_Client_clipboard guestClipboard:enable=true &
 
-flock -n -x /var/lock/civ_startapp.lock pause_civ ||
+exec {CIV_STARTAPP_LOCK_FD}</var/lock/civ_startapp.lock
+if flock -n -x ${CIV_STARTAPP_LOCK_FD} ; then
+    pause_civ
+fi
+exec {CIV_STARTAPP_LOCK_FD}<&-
 
 exit 0


### PR DESCRIPTION
1. Get a file descriptor for the file to be locked
2. Try to acquire the lock by flock, if acquired, then pause_civ
3. Close file descriptor and the file lock will be released automatically.

Signed-off-by: Yadong Qi <yadong.qi@intel.com>